### PR TITLE
Adds support for Visual Studio 2015 and 2017.

### DIFF
--- a/teapot/extensions/builtin.py
+++ b/teapot/extensions/builtin.py
@@ -159,6 +159,8 @@ def msvc_toolset(contexter):
     version = msvc_version(contexter)
 
     toolset_map = {
+        '15.0': 'v141',
+        '14.0': 'v140',
         '12.0': 'v120',
         '11.0': 'v110',
     }


### PR DESCRIPTION
When trying to compile FreeLAN dependencies with Visual Studio 2017, it appears it does not work because Platformtoolset is not defined.